### PR TITLE
Add concurrent jobs and update Stimulus controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Use tags to jump around different stages of the app development:
 |Scaffold of app | base-app | [link](https://github.com/maikhel/hotwire-jokes/tree/base-app) | `git checkout base-app`
 |Broadcast jokes from model | broadcast-with-pagination |[link](https://github.com/maikhel/hotwire-jokes/tree/broadcast-with-pagination) | `git checkout broadcast-with-pagination`
 |Broadcast jokes from job | broadcast-from-job | [link](https://github.com/maikhel/hotwire-jokes/tree/broadcast-from-job) | `git checkout broadcast-from-job`
+|Broadcast with Stimulus | broadcast-with-stimulus | [link](https://github.com/maikhel/hotwire-jokes/tree/broadcast-with-stimulus) | `git checkout broadcast-with-stimulus`
 
 ## Setup
 

--- a/app/controllers/jokes_requests_controller.rb
+++ b/app/controllers/jokes_requests_controller.rb
@@ -8,10 +8,11 @@ class JokesRequestsController < ApplicationController
   end
 
   def show
-    @pagy, @jokes = pagy_array(
-      @jokes_request.jokes.order(id: :asc).pluck(:body),
-      items: Joke::PER_PAGE, link_extra: 'data-turbo-action="advance"'
-    )
+    @jokes = @jokes_request.jokes.order(id: :asc).pluck(:body)
+    # @pagy, @jokes = pagy_array(
+    #   @jokes_request.jokes.order(id: :asc).pluck(:body),
+    #   items: Joke::PER_PAGE, link_extra: 'data-turbo-action="advance"'
+    # )
   end
 
   def new

--- a/app/controllers/jokes_requests_controller.rb
+++ b/app/controllers/jokes_requests_controller.rb
@@ -26,7 +26,7 @@ class JokesRequestsController < ApplicationController
 
     respond_to do |format|
       if @jokes_request.save
-        FetchJokesJob.perform_later(@jokes_request.id)
+        FetchJokesSupervisorJob.perform_later(@jokes_request.id)
         format.html { redirect_to jokes_request_url(@jokes_request), notice: "Jokes request was successfully created." }
       else
         format.html { render :new, status: :unprocessable_entity }

--- a/app/controllers/jokes_requests_controller.rb
+++ b/app/controllers/jokes_requests_controller.rb
@@ -8,11 +8,10 @@ class JokesRequestsController < ApplicationController
   end
 
   def show
-    @jokes = @jokes_request.jokes.order(id: :asc).pluck(:body)
-    # @pagy, @jokes = pagy_array(
-    #   @jokes_request.jokes.order(id: :asc).pluck(:body),
-    #   items: Joke::PER_PAGE, link_extra: 'data-turbo-action="advance"'
-    # )
+    @pagy, @jokes = pagy_array(
+      @jokes_request.jokes.order(id: :asc).pluck(:body),
+      items: Joke::PER_PAGE, link_extra: 'data-turbo-action="advance"'
+    )
   end
 
   def new

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -4,5 +4,8 @@
 
 import { application } from "./application"
 
-import RemovalsController from "./removals_controller.js"
+import ProgressBarController from "./progress_bar_controller"
+application.register("progress-bar", ProgressBarController)
+
+import RemovalsController from "./removals_controller"
 application.register("removals", RemovalsController)

--- a/app/javascript/controllers/progress_bar_controller.js
+++ b/app/javascript/controllers/progress_bar_controller.js
@@ -1,0 +1,36 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="progress-bar"
+export default class extends Controller {
+  static values = {
+    limit: 0,
+    actual: 0
+  }
+  static targets = ["jokesGrid", "progress", "count"]
+  connect() {
+    this.observer = new MutationObserver((mutationsList, _observer) => {
+      for (let mutation of mutationsList) {
+        if (mutation.type === 'childList') {
+          this.increment()
+        }
+      }
+    })
+
+    this.observer.observe(this.jokesGridTarget, { childList: true, subtree: true })
+  }
+
+  increment() {
+    this.actualValue++
+    this.updateProgress()
+    this.updateCount()
+  }
+
+  updateProgress() {
+    let progress = (this.actualValue / this.limitValue) * 100
+    this.progressTarget.style.width = `${progress}%`
+  }
+
+  updateCount() {
+    this.countTarget.innerText = `${this.actualValue} / ${this.limitValue}`
+  }
+}

--- a/app/javascript/controllers/progress_bar_controller.js
+++ b/app/javascript/controllers/progress_bar_controller.js
@@ -5,7 +5,6 @@ export default class extends Controller {
   static values = {
     limit: 0,
     actual: 0,
-    perPage: 9
   }
   static targets = ["jokesGrid", "hiddenJokesGrid", "progress", "count"]
   connect() {
@@ -14,9 +13,6 @@ export default class extends Controller {
         if (mutation.type === 'childList' && mutation.addedNodes.length > 0) {
           mutation.addedNodes.forEach(el => {
             if(el.classList != undefined){
-              if(this.jokesGridTarget.childElementCount === this.perPageValue){
-                this.clearGrid()
-              }
               this.revealJoke(el)
               this.increment()
             }
@@ -47,11 +43,5 @@ export default class extends Controller {
   revealJoke(joke) {
     this.jokesGridTarget.append(joke)
     this.jokesGridTarget.lastChild.classList.remove("hidden")
-  }
-
-  clearGrid(){
-    while (this.jokesGridTarget.firstChild) {
-      this.jokesGridTarget.removeChild(this.jokesGridTarget.firstChild);
-    }
   }
 }

--- a/app/javascript/controllers/progress_bar_controller.js
+++ b/app/javascript/controllers/progress_bar_controller.js
@@ -4,19 +4,29 @@ import { Controller } from "@hotwired/stimulus"
 export default class extends Controller {
   static values = {
     limit: 0,
-    actual: 0
+    actual: 0,
+    perPage: 9
   }
-  static targets = ["jokesGrid", "progress", "count"]
+  static targets = ["jokesGrid", "hiddenJokesGrid", "progress", "count"]
   connect() {
     this.observer = new MutationObserver((mutationsList, _observer) => {
       for (let mutation of mutationsList) {
-        if (mutation.type === 'childList') {
-          this.increment()
+        if (mutation.type === 'childList' && mutation.addedNodes.length > 0) {
+          mutation.addedNodes.forEach(el => {
+            if(el.classList != undefined){
+              if(this.jokesGridTarget.childElementCount === this.perPageValue){
+                this.clearGrid()
+              }
+              this.revealJoke(el)
+              this.increment()
+            }
+          });
+
         }
       }
     })
 
-    this.observer.observe(this.jokesGridTarget, { childList: true, subtree: true })
+    this.observer.observe(this.hiddenJokesGridTarget, { childList: true, subtree: true })
   }
 
   increment() {
@@ -32,5 +42,16 @@ export default class extends Controller {
 
   updateCount() {
     this.countTarget.innerText = `${this.actualValue} / ${this.limitValue}`
+  }
+
+  revealJoke(joke) {
+    this.jokesGridTarget.append(joke)
+    this.jokesGridTarget.lastChild.classList.remove("hidden")
+  }
+
+  clearGrid(){
+    while (this.jokesGridTarget.firstChild) {
+      this.jokesGridTarget.removeChild(this.jokesGridTarget.firstChild);
+    }
   }
 }

--- a/app/jobs/fetch_jokes_job.rb
+++ b/app/jobs/fetch_jokes_job.rb
@@ -1,7 +1,7 @@
 class FetchJokesJob < ApplicationJob
   queue_as :default
 
-  def perform(jokes_request_id)
-    ::FetchJokesService.new(jokes_request_id).call
+  def perform(jokes_request_id, jokes_count)
+    ::FetchJokesService.new(jokes_request_id).perform(jokes_count)
   end
 end

--- a/app/jobs/fetch_jokes_supervisor_job.rb
+++ b/app/jobs/fetch_jokes_supervisor_job.rb
@@ -1,0 +1,13 @@
+class FetchJokesSupervisorJob < ApplicationJob
+  BATCH_SIZE = 25
+  queue_as :default
+
+  def perform(jokes_request_id)
+    jokes_request = JokesRequest.find(jokes_request_id)
+    jokes_to_fetch_count = jokes_request.amount - jokes_request.jokes.size
+
+    (1..jokes_to_fetch_count).each_slice(BATCH_SIZE) do |slice|
+      FetchJokesJob.perform_later(jokes_request_id, slice.size)
+    end
+  end
+end

--- a/app/services/fetch_jokes_service.rb
+++ b/app/services/fetch_jokes_service.rb
@@ -29,8 +29,6 @@ class FetchJokesService
 
   def broadcast_update_to_show_page(joke, num)
     add_joke(joke, num)
-    # update_progress_bar(num)
-    # update_jokes_count(num)
   end
 
   def add_joke(joke, jokes_count)
@@ -56,9 +54,9 @@ class FetchJokesService
   def add_joke_card(joke)
     Turbo::StreamsChannel.broadcast_append_to(
       [ jokes_request, "jokes" ],
-      target: "jokes_grid",
+      target: "hidden_jokes_grid",
       partial: "jokes/joke",
-      locals: { joke: joke }
+      locals: { joke: joke, extra_style: 'hidden' }
     )
   end
 
@@ -72,24 +70,6 @@ class FetchJokesService
       target: "jokes_pagination",
       partial: "jokes_requests/jokes_pagination",
       locals: { pagy: pagy }
-    )
-  end
-
-  def update_progress_bar(number)
-    Turbo::StreamsChannel.broadcast_append_to(
-      [ jokes_request, "jokes_progress_bar" ],
-      target: "jokes_progress_bar",
-      partial: "jokes_requests/jokes_progress_bar",
-      locals: { actual: number, limit: jokes_request.amount }
-    )
-  end
-
-  def update_jokes_count(number)
-    Turbo::StreamsChannel.broadcast_replace_to(
-      [ jokes_request, "jokes_count" ],
-      target: "jokes_count",
-      partial: "jokes_requests/jokes_count",
-      locals: { actual: number, limit: jokes_request.amount }
     )
   end
 

--- a/app/services/fetch_jokes_service.rb
+++ b/app/services/fetch_jokes_service.rb
@@ -8,7 +8,7 @@ class FetchJokesService
     @jokes_request = JokesRequest.find(jokes_request_id)
   end
 
-  def call
+  def perform(missing_jokes_count)
     jokes = []
 
     missing_jokes_count.times do |num|
@@ -91,10 +91,6 @@ class FetchJokesService
       partial: "jokes_requests/jokes_count",
       locals: { actual: number, limit: jokes_request.amount }
     )
-  end
-
-  def missing_jokes_count
-    jokes_request.amount - jokes_request.jokes.size
   end
 
   def make_request

--- a/app/services/fetch_jokes_service.rb
+++ b/app/services/fetch_jokes_service.rb
@@ -16,7 +16,7 @@ class FetchJokesService
       joke = parse_response(response)
 
       @jokes_request.jokes.create(body: joke)
-      broadcast_update_to_show_page(joke, num + 1)
+      broadcast_update_to_show_page(joke)
       sleep(jokes_request.delay) if jokes_request.delay.positive?
     end
 
@@ -27,49 +27,12 @@ class FetchJokesService
 
   attr_reader :jokes_request
 
-  def broadcast_update_to_show_page(joke, num)
-    add_joke(joke, num)
-  end
-
-  def add_joke(joke, jokes_count)
-    last_page = jokes_count / Joke::PER_PAGE + 1
-
-    if false # jokes_count % Joke::PER_PAGE ==  1 # change page to next one
-      clear_all_jokes
-      add_joke_card(joke)
-      replace_pagination(jokes_count, last_page)
-    else
-      add_joke_card(joke)
-    end
-  end
-
-  def clear_all_jokes
-    Turbo::StreamsChannel.broadcast_replace_to(
-      [ jokes_request, "jokes" ],
-      target: "jokes_grid",
-      partial: "jokes_requests/empty_jokes_grid"
-    )
-  end
-
-  def add_joke_card(joke)
+  def broadcast_update_to_show_page(joke)
     Turbo::StreamsChannel.broadcast_append_to(
       [ jokes_request, "jokes" ],
       target: "hidden_jokes_grid",
       partial: "jokes/joke",
-      locals: { joke: joke, extra_style: 'hidden' }
-    )
-  end
-
-  def replace_pagination(jokes_count, last_page)
-    pagy = Pagy.new(count: jokes_count, page: last_page,
-              items: Joke::PER_PAGE,
-              link_extra: 'data-turbo-action="advance"')
-
-    Turbo::StreamsChannel.broadcast_replace_to(
-      [ jokes_request, "jokes_pagination" ],
-      target: "jokes_pagination",
-      partial: "jokes_requests/jokes_pagination",
-      locals: { pagy: pagy }
+      locals: { joke: joke, extra_style: "hidden" }
     )
   end
 

--- a/app/services/fetch_jokes_service.rb
+++ b/app/services/fetch_jokes_service.rb
@@ -29,14 +29,14 @@ class FetchJokesService
 
   def broadcast_update_to_show_page(joke, num)
     add_joke(joke, num)
-    update_progress_bar(num)
-    update_jokes_count(num)
+    # update_progress_bar(num)
+    # update_jokes_count(num)
   end
 
   def add_joke(joke, jokes_count)
     last_page = jokes_count / Joke::PER_PAGE + 1
 
-    if jokes_count % Joke::PER_PAGE ==  1 # change page to next one
+    if false # jokes_count % Joke::PER_PAGE ==  1 # change page to next one
       clear_all_jokes
       add_joke_card(joke)
       replace_pagination(jokes_count, last_page)
@@ -76,7 +76,7 @@ class FetchJokesService
   end
 
   def update_progress_bar(number)
-    Turbo::StreamsChannel.broadcast_replace_to(
+    Turbo::StreamsChannel.broadcast_append_to(
       [ jokes_request, "jokes_progress_bar" ],
       target: "jokes_progress_bar",
       partial: "jokes_requests/jokes_progress_bar",

--- a/app/views/jokes/_joke.html.erb
+++ b/app/views/jokes/_joke.html.erb
@@ -1,3 +1,3 @@
-<div class="bg-slate-200 text-slate-700 text-center text-clip overflow-clip py-4 mb-4 shadow-md rounded px-4">
+<div class="bg-slate-200 text-slate-700 text-center text-clip overflow-clip py-4 mb-4 shadow-md rounded px-4 <%= extra_style %>">
   <%= joke %>
 </div>

--- a/app/views/jokes_requests/_jokes_count.html.erb
+++ b/app/views/jokes_requests/_jokes_count.html.erb
@@ -1,3 +1,4 @@
-<div id="jokes_count">
+<div id="jokes_count"
+     data-progress-bar-target="count">
   <%= "#{actual} / #{limit}"%>
 </div>

--- a/app/views/jokes_requests/_jokes_progress_bar.html.erb
+++ b/app/views/jokes_requests/_jokes_progress_bar.html.erb
@@ -1,5 +1,9 @@
 <% progress_width = actual / limit.to_f * 100 %>
 
-<div id="jokes_progress_bar" class="w-full bg-gray-200 rounded-full">
-  <div class="h-0.5 bg-lime-500 rounded-full" style="width: <%= progress_width.to_i %>%;"></div>
+<div id="jokes_progress_bar"
+     class="w-full bg-gray-200 rounded-full">
+  <div class="h-0.5 bg-lime-500 rounded-full"
+       data-progress-bar-target="progress"
+       style="width: <%= progress_width.to_i %>%;">
+  </div>
 </div>

--- a/app/views/jokes_requests/show.html.erb
+++ b/app/views/jokes_requests/show.html.erb
@@ -36,12 +36,14 @@
 
   <%= render "jokes_progress_bar", actual: @jokes_request.jokes.count, limit: @jokes_request.amount %>
 
+  <div id='hidden_jokes_grid' data-progress-bar-target="hiddenJokesGrid"></div>
+
   <%= turbo_frame_tag "jokes" do %>
     <div id='jokes_grid'
         data-progress-bar-target="jokesGrid"
         class="grid grid-cols-3 gap-4 mt-4">
       <% @jokes.each do |joke| %>
-        <%= render 'jokes/joke', joke: joke %>
+        <%= render 'jokes/joke', joke: joke, extra_style: '' %>
       <% end %>
     </div>
   <% end %>

--- a/app/views/jokes_requests/show.html.erb
+++ b/app/views/jokes_requests/show.html.erb
@@ -1,7 +1,4 @@
 <%= turbo_stream_from @jokes_request, "jokes" %>
-<%= turbo_stream_from @jokes_request, "jokes_count" %>
-<%= turbo_stream_from @jokes_request, "jokes_progress_bar" %>
-<%= turbo_stream_from @jokes_request, "jokes_pagination" %>
 
 <div id="jokes_show"
      data-controller="progress-bar"
@@ -46,6 +43,9 @@
         <%= render 'jokes/joke', joke: joke, extra_style: '' %>
       <% end %>
     </div>
+    <% if @jokes_request.jokes.count > Joke::PER_PAGE %>
+      <%= render "jokes_pagination", pagy: @pagy %>
+    <% end %>
   <% end %>
 
   <div>

--- a/app/views/jokes_requests/show.html.erb
+++ b/app/views/jokes_requests/show.html.erb
@@ -3,43 +3,50 @@
 <%= turbo_stream_from @jokes_request, "jokes_progress_bar" %>
 <%= turbo_stream_from @jokes_request, "jokes_pagination" %>
 
-<div class="flex justify-between items-center mb-4 border-b border-neutral-300">
-  <h2 class="text-xl text-slate-500 font-bold pb-2">Jokes Request #<%= @jokes_request.id %></h2>
-</div>
+<div id="jokes_show"
+     data-controller="progress-bar"
+     data-progress-bar-limit-value="<%= @jokes_request.amount %>"
+     data-progress-bar-actual-value="<%= @jokes_request.jokes.count %>">
 
-<div class="flex mt-1">
-  <div class="font-bold">Created at:</div>
-  <div class="mx-2"><%= @jokes_request.created_at %></div>
-</div>
-
-<div class="flex mt-1">
-  <div class="font-bold">Amount:</div>
-  <div class="mx-2"><%= @jokes_request.amount %></div>
-</div>
-
-<div class="flex mt-1">
-  <div class="font-bold">Delay (in seconds):</div>
-  <div class="mx-2"><%= @jokes_request.delay %></div>
-</div>
-
-<div class="flex mt-1">
-  <div class="font-bold mr-2">Jokes count:</div>
-  <%= render "jokes_count", actual: @jokes_request.jokes.count, limit: @jokes_request.amount %>
-</div>
-
-<h2 class="text-2xl text-lime-500 text-center font-bold pb-2">Jokes</h2>
-
-<%= render "jokes_progress_bar", actual: @jokes_request.jokes.count, limit: @jokes_request.amount %>
-
-<%= turbo_frame_tag "jokes" do %>
-  <div id='jokes_grid' class="grid grid-cols-3 gap-4 mt-4">
-    <% @jokes.each do |joke| %>
-      <%= render 'jokes/joke', joke: joke %>
-    <% end %>
+  <div class="flex justify-between items-center mb-4 border-b border-neutral-300">
+    <h2 class="text-xl text-slate-500 font-bold pb-2">Jokes Request #<%= @jokes_request.id %></h2>
   </div>
-  <%= render "jokes_pagination", pagy: @pagy %>
-<% end %>
 
-<div>
-  <%= link_to sanitize("&larr; Back to jokes requests"), jokes_requests_path, class: "mt-4 inline-block text-slate-500" %>
+  <div class="flex mt-1">
+    <div class="font-bold">Created at:</div>
+    <div class="mx-2"><%= @jokes_request.created_at %></div>
+  </div>
+
+  <div class="flex mt-1">
+    <div class="font-bold">Amount:</div>
+    <div class="mx-2"><%= @jokes_request.amount %></div>
+  </div>
+
+  <div class="flex mt-1">
+    <div class="font-bold">Delay (in seconds):</div>
+    <div class="mx-2"><%= @jokes_request.delay %></div>
+  </div>
+
+  <div class="flex mt-1">
+    <div class="font-bold mr-2">Jokes count:</div>
+    <%= render "jokes_count", actual: @jokes_request.jokes.count, limit: @jokes_request.amount %>
+  </div>
+
+  <h2 class="text-2xl text-lime-500 text-center font-bold pb-2">Jokes</h2>
+
+  <%= render "jokes_progress_bar", actual: @jokes_request.jokes.count, limit: @jokes_request.amount %>
+
+  <%= turbo_frame_tag "jokes" do %>
+    <div id='jokes_grid'
+        data-progress-bar-target="jokesGrid"
+        class="grid grid-cols-3 gap-4 mt-4">
+      <% @jokes.each do |joke| %>
+        <%= render 'jokes/joke', joke: joke %>
+      <% end %>
+    </div>
+  <% end %>
+
+  <div>
+    <%= link_to sanitize("&larr; Back to jokes requests"), jokes_requests_path, class: "mt-4 inline-block text-slate-500" %>
+  </div>
 </div>

--- a/test/jobs/fetch_jokes_supervisor_job_test.rb
+++ b/test/jobs/fetch_jokes_supervisor_job_test.rb
@@ -1,0 +1,27 @@
+require "test_helper"
+
+class FetchJokesSupervisorJobTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
+
+  test "should invoke one service if number of jokes < BATCH_SIZE" do
+    @jokes_request = JokesRequest.create(amount: 20, delay: 0)
+
+    assert_enqueued_jobs 1, only: FetchJokesJob do
+      FetchJokesSupervisorJob.new(@jokes_request.id).perform_now
+    end
+
+    assert [ @jokes_request.id, 20 ], enqueued_jobs[0]["arguments"]
+  end
+
+  test "should invoke more service if number of jokes > BATCH_SIZE" do
+    @jokes_request = JokesRequest.create(amount: 65, delay: 0)
+
+    assert_enqueued_jobs 3, only: FetchJokesJob do
+      FetchJokesSupervisorJob.new(@jokes_request.id).perform_now
+    end
+
+    assert [ @jokes_request.id, 25 ], enqueued_jobs[0]["arguments"]
+    assert [ @jokes_request.id, 25 ], enqueued_jobs[1]["arguments"]
+    assert [ @jokes_request.id, 15 ], enqueued_jobs[2]["arguments"]
+  end
+end

--- a/test/services/fetch_jokes_service_test.rb
+++ b/test/services/fetch_jokes_service_test.rb
@@ -9,27 +9,10 @@ class FetchJokesServiceTest < ActiveSupport::TestCase
     stub_request(:get, FetchJokesService::API_ENDPOINT)
       .to_return(status: 200, body: { value: "Chuck Norris can divide by zero." }.to_json)
 
-    assert FetchJokesService.new(@jokes_request.id).call, true
+    assert FetchJokesService.new(@jokes_request.id).perform(3), true
 
     assert_equal 3, @jokes_request.jokes.count
     @jokes_request.jokes.each do |joke|
-      assert_equal "Chuck Norris can divide by zero.", joke.body
-    end
-  end
-
-
-  test "should fetch only missing jokes (up to requested amount)" do
-    stub_request(:get, FetchJokesService::API_ENDPOINT)
-      .to_return(status: 200, body: { value: "Chuck Norris can divide by zero." }.to_json)
-
-    existing_joke = Joke.create!(jokes_request: @jokes_request,
-                                 body: "Pain and death is what Chuck Norris makes it.")
-
-    assert FetchJokesService.new(@jokes_request.id).call, true
-
-    assert_equal 3, @jokes_request.jokes.count
-    assert_equal existing_joke.body, @jokes_request.jokes.first.body
-    @jokes_request.jokes.last(2).each do |joke|
       assert_equal "Chuck Norris can divide by zero.", joke.body
     end
   end
@@ -38,7 +21,7 @@ class FetchJokesServiceTest < ActiveSupport::TestCase
     stub_request(:get, FetchJokesService::API_ENDPOINT)
       .to_return(status: 200, body: "invalid json")
 
-    assert FetchJokesService.new(@jokes_request.id).call, true
+    assert FetchJokesService.new(@jokes_request.id).perform(3), true
 
     assert_equal 0, @jokes_request.jokes.count
   end
@@ -47,7 +30,7 @@ class FetchJokesServiceTest < ActiveSupport::TestCase
     stub_request(:get, FetchJokesService::API_ENDPOINT)
       .to_return(status: 422, body: { message: "Unauthorized" }.to_json)
 
-    assert FetchJokesService.new(@jokes_request.id).call, true
+    assert FetchJokesService.new(@jokes_request.id).perform(3), true
 
     assert_equal 0, @jokes_request.jokes.count
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,6 +2,7 @@ ENV["RAILS_ENV"] ||= "test"
 require_relative "../config/environment"
 require "rails/test_help"
 require "webmock/minitest"
+require "minitest/autorun"
 
 module ActiveSupport
   class TestCase


### PR DESCRIPTION
**Done:**
- make job parallel if more than 25 jokes to fetch
- update progress bar and jokes count via Stimulus controller
- don't update pagination when adding new jokes (for now)


New solution architecture:
![broadcast_after](https://github.com/maikhel/hotwire-jokes/assets/10177275/455524be-3bf3-4014-bdf4-a7ac89637eca)
